### PR TITLE
Redirecionamento do usuário não autenticado

### DIFF
--- a/ecoshare/ecoshare/settings.py
+++ b/ecoshare/ecoshare/settings.py
@@ -116,6 +116,9 @@ USE_TZ = True
 
 STATIC_URL = 'static/'
 
+# Configurações de autenticação
+LOGIN_URL = 'login'
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
 


### PR DESCRIPTION
Agora quando um usuário que não está autenticado, ou seja, logado em sua conta e tenta acessar alguns links que estão restringidos, ele será redirecionado automaticamente para a página de login.